### PR TITLE
FEAT: change name every time splash loads

### DIFF
--- a/src/components/SplashPage.tsx
+++ b/src/components/SplashPage.tsx
@@ -2,14 +2,27 @@ import React from 'react';
 import './SplashPage.css';
 import Navbar from './Navbar';
 
+const nameArray = ["rocket-powered turbo chickens", "rocket-powered grenade chickens", "missile-guided fire chickens", "fire eagles with rockets", "rocket-fueled chicken farmers", "flaming space hens", "inferno chickens", "pyro-driven roosters", "celestial blaze chickens", "meteoric fire birds", "jet-propelled firebirds"];
+
+const getRandomName =() => {
+    const randomIndex = Math.floor(Math.random() * nameArray.length);
+    return nameArray[randomIndex];
+};
+
 const SplashPage: React.FC = () => {
+    const [groupName, setGroupName] = React.useState(getRandomName());
+
+    React.useEffect(()=> {
+        setGroupName(getRandomName());
+    }, []);
+
     return (
         <div> <Navbar />
             <div className="splash-page">
                 <header className="header">
                     <h1 className="tagline">We are Armor-E</h1>
                     <p className="description">
-                        aka the rocket powered turbo chickens
+                        aka {groupName}
                     </p>
                     <button className="learn-more">Learn More</button>
                 </header>


### PR DESCRIPTION
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Added a fun feature to change the name of the group every time the page loads.

## Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I've followed the [Contributing guidelines](https://github.com/oslabs-beta/.github/blob/main/docs/CONTRIBUTING.md)
- [x ] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [x ] I've added tests that fail without this PR but pass with it
- [x ] I've linted, tested, and commented my code
- [x ] I've updated documentation (if appropriate)
